### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @anthony-j-castro

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "anthony-j-castro"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "anthony-j-castro"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
+      interval: "daily"
+    reviewers:
+      - "anthony-j-castro"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
       interval: "weekly"
-      day: "wednesday"
     reviewers:
       - "anthony-j-castro"


### PR DESCRIPTION
Updates dependabot settings:
* Switch from checking for `npm` dependencies from weekly to daily
* Add weekly check for updates to GitHub Actions
* Remove `reviewers` setting and rely on new `CODEOWNERS` file