### PR TITLE
Update `typescript` from 4.9.5 to 5.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-react": "7.33.0",
         "prettier": "3.0.0",
-        "typescript": "4.9.5"
+        "typescript": "5.1.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -14845,15 +14845,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,12 @@
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "7.33.0",
     "prettier": "3.0.0",
-    "typescript": "4.9.5"
+    "typescript": "5.1.6"
+  },
+  "overrides": {
+    "react-scripts": {
+      "typescript": "$typescript"
+    }
   },
   "browserslist": {
     "production": [">0.2%", "not dead", "not op_mini all"],


### PR DESCRIPTION
Updates `typescript` from 4.9.5 to 5.1.6, and includes and override for `react-scripts` to use the same version as the project's direct dependency.