### PR TITLE
Run test workflow on every branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,7 @@
 name: Test branch
 
 on:
-  push:
-    branches-ignore:
-      - main
+  push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Removes branch filtering from the "Test branch" workflow since we want it to run on `main` now too.