### PR TITLE
Add failure case to deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-pages.yml
+++ b/.github/workflows/deploy-to-pages.yml
@@ -24,9 +24,18 @@ jobs:
       - name: Ready
         run: exit 1
 
-  build:
+  fail:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Fail
+        run: |
+          echo "Required workflow was not successful"
+          exit 1
+
+  build:
     needs: ready
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -47,11 +56,11 @@ jobs:
           path: ./build
 
   deploy:
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
In case the required workflow does not succeed, this will ensure that the deploy workflow shows as failed in the GitHub Actions UI.