### PR TITLE
Prevent analytics tracking in Cypress tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build/*",
-    "build:cy": "REACT_APP_GOOGLE_ANALYTICS_MEASUREMENT_ID=G-GES4DQN2RP react-scripts build",
+    "build:cy": "REACT_APP_GOOGLE_ANALYTICS_MEASUREMENT_ID= react-scripts build",
     "serve:cy": "serve -s build",
     "cy:run": "cypress run"
   },


### PR DESCRIPTION
Blanks out the Google Analytics measurement ID so that no analytics are reported during Cypress tests in CI.

Note: this wasn't inflating analytics since the measurement ID was for the sandbox environment, but it's still good to not send anything at all since I prefer to use that environment for development.