### PR TITLE
Silence eslint warnings in CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   env: { browser: true, node: true },
   extends: ["@anthony-j-castro/eslint-config"],
+  rules: {
+    "no-restricted-imports": "off",
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
   env: { browser: true, node: true },
   extends: ["@anthony-j-castro/eslint-config"],
-  rules: {
-    "no-restricted-imports": "off",
-  },
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
       - name: Lint
-        run: npm run lint
+        run: npm run lint:ci
       - name: Build for Cypress
         run: npm run build:cy
         env: 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "lint": "eslint .",
+    "lint:ci": "eslint . --quiet",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build/*",
     "build:cy": "REACT_APP_GOOGLE_ANALYTICS_MEASUREMENT_ID= react-scripts build",


### PR DESCRIPTION
ESLint warning annotations were getting a little annoying. I added a new `lint:ci` command that uses the `--quiet` flag so that warnings are not reported in GH action workflows.