### PR TITLE
Fix @typescript-eslint dependencies group in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     groups:
       "@typescript-eslint":
         patterns:
-          - "^@typescript-eslint/.*"
+          - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is a followup to https://github.com/anthony-j-castro/anthonyjcastro-dot-com/pull/111. It seems the config might not be correct, since dependabot ended up opening separate PRs for these packages.