### PR TITLE
Group babel package updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "daily"
     groups:    
-      "@babel":
+      babel:
         patterns:
           - "@babel/*"
-      "@typescript-eslint":
+      typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
+    groups:    
+      "@babel":
+        patterns:
+          - "@babel/*"
       "@typescript-eslint":
         patterns:
           - "@typescript-eslint/*"


### PR DESCRIPTION
Similar to `typescript-eslint` packages, `babel` packages get their versions bumped together, so let's have Dependabot group them.