### PR TITLE
Generate and upload screenshots/videos for Cypress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,15 @@ jobs:
           start: npm run serve:cy
           wait-on: "http://localhost:3000"
       - uses: actions/upload-artifact@v4
-        # add the line below to store screenshots only on failures
-        # if: failure()
+        if: always()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-          if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+          if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: cypress-videos
           path: cypress/videos
-          if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+          if-no-files-found: ignore
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,16 @@ jobs:
           browser: chrome
           start: npm run serve:cy
           wait-on: "http://localhost:3000"
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Upload Cypress videos
+        uses: actions/upload-artifact@v4
+        if: failure()
         with:
           name: cypress-videos
           path: cypress/videos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,16 @@ jobs:
           browser: chrome
           start: npm run serve:cy
           wait-on: "http://localhost:3000"
+      - uses: actions/upload-artifact@v4
+        # add the line below to store screenshots only on failures
+        # if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   e2e: {
     supportFile: false,
   },
+  video: true,
 });

--- a/cypress/e2e/render.cy.ts
+++ b/cypress/e2e/render.cy.ts
@@ -1,6 +1,6 @@
 describe("The home page", () => {
   it("successfully loads", () => {
     cy.visit("http://localhost:3000");
-    cy.get('[data-cy="greetings"]').should("exist");
+    cy.get('[data-cy="greeting"]').should("exist");
   });
 });

--- a/cypress/e2e/render.cy.ts
+++ b/cypress/e2e/render.cy.ts
@@ -1,6 +1,6 @@
 describe("The home page", () => {
   it("successfully loads", () => {
     cy.visit("http://localhost:3000");
-    cy.get('[data-cy="greeting"]').should("exist");
+    cy.get('[data-cy="greetings"]').should("exist");
   });
 });


### PR DESCRIPTION
This PR configures Cypress to generate screenshots and videos, and upload them as artifacts to the CI job whenever Cypress tests fail.