### PR TITLE
chore: Update modern-normalize

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,10 @@
   },
   "eslint.validate": ["javascript", "typescript"],
   "typescript.validate.enable": true,
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
   "[html]": {
     "editor.defaultFormatter": "vscode.html-language-features"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@analytics/google-analytics": "1.0.7",
         "analytics": "0.8.14",
-        "modern-normalize": "2.0.0",
+        "modern-normalize": "3.0.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "styled-components": "6.1.12"
@@ -10166,9 +10166,9 @@
       }
     },
     "node_modules/modern-normalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-2.0.0.tgz",
-      "integrity": "sha512-CxBoEVKh5U4DH3XuNbc5ONLF6dQBc8dSc7pdZ1957FGbIO5JBqGqqchhET9dTexri8/pk9xBL6+5ceOtCIp1QA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-3.0.0.tgz",
+      "integrity": "sha512-oY2uocgMUQC33i5rKZMWzhyJ+U2nsoiHDYyoDVFxYVBob8RIjZoCbRSbE4+a2/SfbGmZOhOJIavLrzz3BC72tw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@analytics/google-analytics": "1.0.7",
     "analytics": "0.8.14",
-    "modern-normalize": "2.0.0",
+    "modern-normalize": "3.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "styled-components": "6.1.12"

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import 'modern-normalize/modern-normalize.css';
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500&display=swap");
 
 html {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import 'modern-normalize/modern-normalize.css';
+@import "modern-normalize/modern-normalize.css";
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500&display=swap");
 
 html {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./components/App";
-import "modern-normalize";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);


### PR DESCRIPTION
I was not importing the CSS as recommended. When I upgraded `modern-normalize` to version 3.0.0, I ran into an issue where the CSS was not being injected at all because the file was being tree-shaken out.

This PR updates the package and imports the CSS per the README.